### PR TITLE
Implement basic player creation screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,7 @@
-<<<<<<< HEAD
-# React + TypeScript + Vite
+# Cheerz Board Game
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This project is a small React + TypeScript application used to experiment with a board game prototype.
 
-Currently, two official plugins are available:
+## Player creation
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
-
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
-=======
-# cheerz
->>>>>>> 4b0e3b584ca2bae748292a12e7b74dafcf5893c7
+At launch you are presented with a screen allowing the creation of players. You can add up to ten players, each with a first name and an optional color.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,36 +1,11 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import PlayerSetup from './components/PlayerSetup'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <h1 className="text-3xl font-bold text-red-500">Hello Tailwind</h1>
-
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="p-4">
+      <PlayerSetup />
+    </div>
   )
 }
 

--- a/src/components/PlayerSetup.tsx
+++ b/src/components/PlayerSetup.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react'
+
+interface Player {
+  name: string
+  color: string
+}
+
+function PlayerSetup() {
+  const [players, setPlayers] = useState<Player[]>([])
+  const [name, setName] = useState('')
+  const [color, setColor] = useState('#000000')
+
+  const addPlayer = () => {
+    if (!name.trim() || players.length >= 10) return
+    setPlayers([...players, { name: name.trim(), color }])
+    setName('')
+    setColor('#000000')
+  }
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Création des joueurs</h2>
+      {players.length < 10 && (
+        <div className="flex gap-2 items-center mb-4">
+          <input
+            className="border px-2 py-1"
+            type="text"
+            placeholder="Prénom"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <input
+            type="color"
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+          />
+          <button className="border px-2 py-1" onClick={addPlayer}>
+            Ajouter
+          </button>
+        </div>
+      )}
+      <ul className="space-y-1">
+        {players.map((player, index) => (
+          <li key={index} className="flex items-center gap-2">
+            <span
+              className="w-4 h-4 inline-block"
+              style={{ backgroundColor: player.color }}
+            />
+            <span>{player.name}</span>
+          </li>
+        ))}
+      </ul>
+      {players.length >= 10 && (
+        <p className="text-sm text-red-500 mt-2">Limite de 10 joueurs atteinte</p>
+      )}
+    </div>
+  )
+}
+
+export default PlayerSetup


### PR DESCRIPTION
## Summary
- reset README for a simple description of the board game prototype
- add a PlayerSetup component for entering players
- render PlayerSetup from App

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_686aa7ca46348326bc1dc7e9324bcdba