### PR TITLE
Implement basic turn-based board game

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,18 @@
 import './App.css'
-import PlayerSetup from './components/PlayerSetup'
+import { useState } from 'react'
+import PlayerSetup, { Player } from './components/PlayerSetup'
+import GameBoard from './components/GameBoard'
 
 function App() {
+  const [players, setPlayers] = useState<Player[] | null>(null)
+
   return (
     <div className="p-4">
-      <PlayerSetup />
+      {players ? (
+        <GameBoard players={players} />
+      ) : (
+        <PlayerSetup onStart={(p) => setPlayers(p)} />
+      )}
     </div>
   )
 }

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+import type { Player } from './PlayerSetup'
+
+interface GamePlayer extends Player {
+  position: number
+}
+
+function GameBoard({ players }: { players: Player[] }) {
+  const [gamePlayers, setGamePlayers] = useState<GamePlayer[]>(
+    players.map((p) => ({ ...p, position: 0 })),
+  )
+  const [current, setCurrent] = useState(0)
+  const [dice, setDice] = useState<number | null>(null)
+  const [winner, setWinner] = useState<string | null>(null)
+
+  const rollDice = () => {
+    if (winner) return
+    const roll = Math.ceil(Math.random() * 6)
+    setDice(roll)
+    const newPos = Math.min(gamePlayers[current].position + roll, 27)
+    setGamePlayers((prev) => {
+      const updated = [...prev]
+      updated[current] = { ...prev[current], position: newPos }
+      return updated
+    })
+    if (newPos >= 27) {
+      setWinner(gamePlayers[current].name)
+    } else {
+      setCurrent((current + 1) % gamePlayers.length)
+    }
+  }
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Plateau de jeu</h2>
+      <div className="grid grid-cols-7 gap-1 w-fit mx-auto mb-4">
+        {Array.from({ length: 28 }, (_, i) => (
+          <div key={i} className="w-12 h-12 border flex flex-wrap items-center justify-center">
+            {gamePlayers
+              .filter((p) => p.position === i)
+              .map((p) => (
+                <span
+                  key={p.name}
+                  className="w-3 h-3 rounded-full m-0.5"
+                  style={{ backgroundColor: p.color }}
+                />
+              ))}
+          </div>
+        ))}
+      </div>
+      {!winner && (
+        <div className="mb-4">
+          <p className="mb-2">Au tour de {gamePlayers[current].name}</p>
+          <button onClick={rollDice}>Lancer le dé</button>
+          {dice && <p className="mt-2">Dé : {dice}</p>}
+        </div>
+      )}
+      {winner && <p className="text-lg font-bold">{winner} a gagné !</p>}
+    </div>
+  )
+}
+
+export default GameBoard

--- a/src/components/PlayerSetup.tsx
+++ b/src/components/PlayerSetup.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react'
 
-interface Player {
+export interface Player {
   name: string
   color: string
 }
 
-function PlayerSetup() {
+interface Props {
+  onStart: (players: Player[]) => void
+}
+
+function PlayerSetup({ onStart }: Props) {
   const [players, setPlayers] = useState<Player[]>([])
   const [name, setName] = useState('')
   const [color, setColor] = useState('#000000')
@@ -52,6 +56,11 @@ function PlayerSetup() {
       </ul>
       {players.length >= 10 && (
         <p className="text-sm text-red-500 mt-2">Limite de 10 joueurs atteinte</p>
+      )}
+      {players.length >= 2 && (
+        <button className="mt-4 border px-2 py-1" onClick={() => onStart(players)}>
+          Jouer
+        </button>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- add a GameBoard component with 28 squares
- allow PlayerSetup to start the game when at least two players are created
- manage game state in App to switch from setup to board

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: Cannot find module './App.css' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686aa9671a3c83268f90d6109e5e082d