### PR TITLE
Add 3D dice rolling animation

### DIFF
--- a/src/components/Dice.tsx
+++ b/src/components/Dice.tsx
@@ -1,19 +1,34 @@
 import React from 'react'
 
-const faces = ['\u2680', '\u2681', '\u2682', '\u2683', '\u2684', '\u2685']
-
 interface DiceProps {
   value: number | null
   rolling: boolean
 }
 
+const rotations: Record<number, string> = {
+  1: 'rotateX(0deg) rotateY(0deg)',
+  2: 'rotateX(-90deg) rotateY(0deg)',
+  3: 'rotateY(-90deg)',
+  4: 'rotateY(90deg)',
+  5: 'rotateX(90deg) rotateY(0deg)',
+  6: 'rotateY(180deg)'
+}
+
 export default function Dice({ value, rolling }: DiceProps) {
-  const face = value ? faces[value - 1] : faces[0]
+  const transform = value ? rotations[value] : rotations[1]
   return (
-    <div
-      className={`w-16 h-16 bg-white text-black text-4xl flex items-center justify-center rounded-lg border-2 border-gray-900 ${rolling ? 'animate-spin duration-500' : ''}`}
-    >
-      {face}
+    <div className="perspective-500">
+      <div
+        className={`relative w-16 h-16 transform-preserve-3d transition-transform duration-700 ${rolling ? 'animate-dice-roll' : ''}`}
+        style={{ transform }}
+      >
+        <div className="absolute inset-0 bg-white border-2 border-gray-900 flex items-center justify-center" style={{ transform: 'translateZ(32px)' }}>1</div>
+        <div className="absolute inset-0 bg-white border-2 border-gray-900 flex items-center justify-center" style={{ transform: 'rotateX(90deg) translateZ(32px)' }}>2</div>
+        <div className="absolute inset-0 bg-white border-2 border-gray-900 flex items-center justify-center" style={{ transform: 'rotateY(-90deg) translateZ(32px)' }}>3</div>
+        <div className="absolute inset-0 bg-white border-2 border-gray-900 flex items-center justify-center" style={{ transform: 'rotateY(90deg) translateZ(32px)' }}>4</div>
+        <div className="absolute inset-0 bg-white border-2 border-gray-900 flex items-center justify-center" style={{ transform: 'rotateX(-90deg) translateZ(32px)' }}>5</div>
+        <div className="absolute inset-0 bg-white border-2 border-gray-900 flex items-center justify-center" style={{ transform: 'rotateY(180deg) translateZ(32px)' }}>6</div>
+      </div>
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -70,3 +70,13 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+/* 3D dice styles */
+.perspective-500 { perspective: 500px; }
+.transform-preserve-3d { transform-style: preserve-3d; }
+@keyframes dice-roll {
+  0% { transform: rotateX(0deg) rotateY(0deg); }
+  100% { transform: rotateX(360deg) rotateY(360deg); }
+}
+.animate-dice-roll { animation: dice-roll 1s linear infinite; }
+


### PR DESCRIPTION
## Summary
- create a real 3D cube for the dice
- spin the cube while rolling

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'babel__core')*
- `npm run lint` *(fails: Cannot find package '/workspace/cheerz/node_modules/@eslint/js/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_686ad45365d4832695cdc2ecd7ab4632