### PR TITLE
Refactor board layout into separate components

### DIFF
--- a/src/components/BoardSquare.tsx
+++ b/src/components/BoardSquare.tsx
@@ -1,0 +1,52 @@
+import PlayerToken from './PlayerToken'
+import type { GamePlayer } from './PlayerToken'
+
+interface Square {
+  id: number
+  x: number
+  y: number
+  color?: string
+  type?: 'star' | 'finish'
+}
+
+interface Props {
+  square: Square
+  scale: number
+  players: GamePlayer[]
+  TILE: number
+  OFFSET: { x: number; y: number }
+}
+
+export default function BoardSquare({ square: sq, scale, players, TILE, OFFSET }: Props) {
+  const tokens = players.filter((p) => p.position === sq.id)
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        width: TILE * scale,
+        height: TILE * scale,
+        left: (sq.x + OFFSET.x) * scale,
+        top: (sq.y + OFFSET.y) * scale,
+        transform: 'translate(-50%, -50%)'
+      }}
+      className="flex items-center justify-center transition-transform duration-300 hover:scale-110"
+    >
+      {sq.type === 'star' ? (
+        <span className="text-yellow-300 text-5xl drop-shadow-md animate-pulse">★</span>
+      ) : (
+        <div
+          className="w-full h-full border-2 border-white shadow-lg"
+          style={{
+            background: `linear-gradient(145deg, ${sq.color}33, ${sq.color})`,
+            borderRadius: '50% 20% 50% 20%'
+          }}
+        />
+      )}
+      <div className="absolute inset-0 flex items-center justify-center gap-1 z-20">
+        {tokens.map((p) => (
+          <PlayerToken key={p.name} player={p} scale={scale} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,6 +1,8 @@
-import { useState, useEffect, useRef } from "react";
-import Dice from "./Dice";
-import type { Player } from "./PlayerSetup";
+import { useState, useEffect, useRef } from 'react'
+import Dice from './Dice'
+import BoardSquare from './BoardSquare'
+import type { Player } from './PlayerSetup'
+import type { GamePlayer } from './PlayerToken'
 
 interface Square {
   id: number;
@@ -48,9 +50,6 @@ export const BOARD: Square[] = [
 
 const LAST = BOARD.length - 1;
 
-interface GamePlayer extends Player {
-  position: number;
-}
 
 export default function GameBoard({ players }: { players: Player[] }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -116,48 +115,14 @@ export default function GameBoard({ players }: { players: Player[] }) {
         }}
       >
         {BOARD.map((sq) => (
-          <div
+          <BoardSquare
             key={sq.id}
-            style={{
-              position: 'absolute',
-              width: TILE * scale,
-              height: TILE * scale,
-              left: (sq.x + OFFSET.x) * scale,
-              top: (sq.y + OFFSET.y) * scale,
-              transform: 'translate(-50%, -50%)'
-            }}
-            className="flex items-center justify-center transition-transform duration-300 hover:scale-110"
-          >
-            {sq.type === 'star' ? (
-              <span className="text-yellow-300 text-5xl drop-shadow-md animate-pulse">★</span>
-            ) : (
-              <div
-                className="w-full h-full border-2 border-white shadow-lg"
-                style={{
-                  background: `linear-gradient(145deg, ${sq.color}33, ${sq.color})`,
-                  borderRadius: '50% 20% 50% 20%',
-                }}
-              />
-            )}
-            <div className="absolute inset-0 flex items-center justify-center gap-1 z-20">
-              {gamePlayers
-                .filter((p) => p.position === sq.id)
-                .map((p) => (
-                  <div
-                    key={p.name}
-                    className="rounded-full border-4 border-white shadow-2xl flex items-center justify-center text-white font-bold"
-                    style={{
-                      backgroundColor: p.color,
-                      width: 40 * scale,
-                      height: 40 * scale,
-                      fontSize: 16 * scale,
-                    }}
-                  >
-                    {p.name.charAt(0)}
-                  </div>
-                ))}
-            </div>
-          </div>
+            square={sq}
+            scale={scale}
+            players={gamePlayers}
+            TILE={TILE}
+            OFFSET={OFFSET}
+          />
         ))}
       </div>
       <div className="mt-8 text-center space-y-4">

--- a/src/components/PlayerToken.tsx
+++ b/src/components/PlayerToken.tsx
@@ -1,0 +1,26 @@
+import type { Player } from './PlayerSetup'
+
+export interface GamePlayer extends Player {
+  position: number
+}
+
+interface Props {
+  player: GamePlayer
+  scale: number
+}
+
+export default function PlayerToken({ player, scale }: Props) {
+  return (
+    <div
+      className="rounded-full border-4 border-white shadow-2xl flex items-center justify-center text-white font-bold"
+      style={{
+        backgroundColor: player.color,
+        width: 40 * scale,
+        height: 40 * scale,
+        fontSize: 16 * scale
+      }}
+    >
+      {player.name.charAt(0)}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `BoardSquare` and `PlayerToken` components
- simplify `GameBoard` by using the new components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ad52eacf48326a53688652814b1be